### PR TITLE
Bring tools.namespace up to date?

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 
 ## 0.3.x series
 
+### Version 0.3.0
+
+  * Released as non-alpha, still some known issues to fix in future.
+
 ### Version 0.3.0-alpha4 on 25-Apr-2017
 
   * Fix [TNS-47]: Always use canonical directory paths when searching

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 # Change Log for tools.namespace
 
-## 1.0.x series
+## 1.x series
+
+### Version 1.1.0
+
+  * [tools.reader] version 1.3.4
 
 ### Version 1.0.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log for tools.namespace
 
+## 1.0.x series
+
+### Version 1.0.0
+
+  * No changes from previous
 
 ## 0.3.x series
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,15 @@
 
 ## 0.3.x series
 
+### Version 0.3.1
+
+  * Fix [TNS-54](https://clojure.atlassian.net/browse/TNS-54): update
+    java.classpath dependency to fix issues on Java 9+
+
+  * [java.classpath] version 0.3.0
+
+  * [tools.reader] version 1.3.2
+
 ### Version 0.3.0
 
   * Released as non-alpha, still some known issues to fix in future.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,12 +3,10 @@ This is a [Clojure contrib] project.
 Under the Clojure contrib [guidelines], this project cannot accept
 pull requests. All patches must be submitted via [JIRA].
 
-See [Contributing] and the [FAQ] on the Clojure development [wiki] for
+See [Contributing] on the Clojure website for
 more information on how to contribute.
 
-[Clojure contrib]: http://dev.clojure.org/display/doc/Clojure+Contrib
-[Contributing]: http://dev.clojure.org/display/community/Contributing
-[FAQ]: http://dev.clojure.org/display/community/Contributing+FAQ
+[Clojure contrib]: https://clojure.org/community/contrib_libs
+[Contributing]: https://clojure.org/community/contributing
 [JIRA]: http://dev.clojure.org/jira/browse/TNS
-[guidelines]: http://dev.clojure.org/display/community/Guidelines+for+Clojure+Contrib+committers
-[wiki]: http://dev.clojure.org/
+[guidelines]: https://clojure.org/community/contrib_howto

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,5 +8,5 @@ more information on how to contribute.
 
 [Clojure contrib]: https://clojure.org/community/contrib_libs
 [Contributing]: https://clojure.org/community/contributing
-[JIRA]: http://dev.clojure.org/jira/browse/TNS
+[JIRA]: https://clojure.atlassian.net/browse/TNS
 [guidelines]: https://clojure.org/community/contrib_howto

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,205 @@
+Eclipse Public License - v 1.0
+
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM
+CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+a) in the case of the initial Contributor, the initial code and documentation
+   distributed under this Agreement, and
+b) in the case of each subsequent Contributor:
+    i) changes to the Program, and
+   ii) additions to the Program;
+
+   where such changes and/or additions to the Program originate from and are
+   distributed by that particular Contributor. A Contribution 'originates'
+   from a Contributor if it was added to the Program by such Contributor
+   itself or anyone acting on such Contributor's behalf. Contributions do not
+   include additions to the Program which: (i) are separate modules of
+   software distributed in conjunction with the Program under their own
+   license agreement, and (ii) are not derivative works of the Program.
+
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are
+necessarily infringed by the use or sale of its Contribution alone or when
+combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement,
+including all Contributors.
+
+2. GRANT OF RIGHTS
+  a) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free copyright license to
+     reproduce, prepare derivative works of, publicly display, publicly
+     perform, distribute and sublicense the Contribution of such Contributor,
+     if any, and such derivative works, in source code and object code form.
+  b) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free patent license under
+     Licensed Patents to make, use, sell, offer to sell, import and otherwise
+     transfer the Contribution of such Contributor, if any, in source code and
+     object code form. This patent license shall apply to the combination of
+     the Contribution and the Program if, at the time the Contribution is
+     added by the Contributor, such addition of the Contribution causes such
+     combination to be covered by the Licensed Patents. The patent license
+     shall not apply to any other combinations which include the Contribution.
+     No hardware per se is licensed hereunder.
+  c) Recipient understands that although each Contributor grants the licenses
+     to its Contributions set forth herein, no assurances are provided by any
+     Contributor that the Program does not infringe the patent or other
+     intellectual property rights of any other entity. Each Contributor
+     disclaims any liability to Recipient for claims brought by any other
+     entity based on infringement of intellectual property rights or
+     otherwise. As a condition to exercising the rights and licenses granted
+     hereunder, each Recipient hereby assumes sole responsibility to secure
+     any other intellectual property rights needed, if any. For example, if a
+     third party patent license is required to allow Recipient to distribute
+     the Program, it is Recipient's responsibility to acquire that license
+     before distributing the Program.
+  d) Each Contributor represents that to its knowledge it has sufficient
+     copyright rights in its Contribution, if any, to grant the copyright
+     license set forth in this Agreement.
+
+3. REQUIREMENTS
+
+A Contributor may choose to distribute the Program in object code form under
+its own license agreement, provided that:
+
+  a) it complies with the terms and conditions of this Agreement; and
+  b) its license agreement:
+      i) effectively disclaims on behalf of all Contributors all warranties
+         and conditions, express and implied, including warranties or
+         conditions of title and non-infringement, and implied warranties or
+         conditions of merchantability and fitness for a particular purpose;
+     ii) effectively excludes on behalf of all Contributors all liability for
+         damages, including direct, indirect, special, incidental and
+         consequential damages, such as lost profits;
+    iii) states that any provisions which differ from this Agreement are
+         offered by that Contributor alone and not by any other party; and
+     iv) states that source code for the Program is available from such
+         Contributor, and informs licensees how to obtain it in a reasonable
+         manner on or through a medium customarily used for software exchange.
+
+When the Program is made available in source code form:
+
+  a) it must be made available under this Agreement; and
+  b) a copy of this Agreement must be included with each copy of the Program.
+     Contributors may not remove or alter any copyright notices contained
+     within the Program.
+
+Each Contributor must identify itself as the originator of its Contribution,
+if
+any, in a manner that reasonably allows subsequent Recipients to identify the
+originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities with
+respect to end users, business partners and the like. While this license is
+intended to facilitate the commercial use of the Program, the Contributor who
+includes the Program in a commercial product offering should do so in a manner
+which does not create potential liability for other Contributors. Therefore,
+if a Contributor includes the Program in a commercial product offering, such
+Contributor ("Commercial Contributor") hereby agrees to defend and indemnify
+every other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits and
+other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such Commercial
+Contributor in connection with its distribution of the Program in a commercial
+product offering. The obligations in this section do not apply to any claims
+or Losses relating to any actual or alleged intellectual property
+infringement. In order to qualify, an Indemnified Contributor must:
+a) promptly notify the Commercial Contributor in writing of such claim, and
+b) allow the Commercial Contributor to control, and cooperate with the
+Commercial Contributor in, the defense and any related settlement
+negotiations. The Indemnified Contributor may participate in any such claim at
+its own expense.
+
+For example, a Contributor might include the Program in a commercial product
+offering, Product X. That Contributor is then a Commercial Contributor. If
+that Commercial Contributor then makes performance claims, or offers
+warranties related to Product X, those performance claims and warranties are
+such Commercial Contributor's responsibility alone. Under this section, the
+Commercial Contributor would have to defend claims against the other
+Contributors related to those performance claims and warranties, and if a
+court requires any other Contributor to pay any damages as a result, the
+Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each
+Recipient is solely responsible for determining the appropriateness of using
+and distributing the Program and assumes all risks associated with its
+exercise of rights under this Agreement , including but not limited to the
+risks and costs of program errors, compliance with applicable laws, damage to
+or loss of data, programs or equipment, and unavailability or interruption of
+operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
+LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this Agreement, and without further action by the
+parties hereto, such provision shall be reformed to the minimum extent
+necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+(excluding combinations of the Program with other software or hardware)
+infringes such Recipient's patent(s), then such Recipient's rights granted
+under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to
+comply with any of the material terms or conditions of this Agreement and does
+not cure such failure in a reasonable period of time after becoming aware of
+such noncompliance. If all Recipient's rights under this Agreement terminate,
+Recipient agrees to cease use and distribution of the Program as soon as
+reasonably practicable. However, Recipient's obligations under this Agreement
+and any licenses granted by Recipient relating to the Program shall continue
+and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in
+order to avoid inconsistency the Agreement is copyrighted and may only be
+modified in the following manner. The Agreement Steward reserves the right to
+publish new versions (including revisions) of this Agreement from time to
+time. No one other than the Agreement Steward has the right to modify this
+Agreement. The Eclipse Foundation is the initial Agreement Steward. The
+Eclipse Foundation may assign the responsibility to serve as the Agreement
+Steward to a suitable separate entity. Each new version of the Agreement will
+be given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version of the
+Agreement is published, Contributor may elect to distribute the Program
+(including its Contributions) under the new version. Except as expressly
+stated in Sections 2(a) and 2(b) above, Recipient receives no rights or
+licenses to the intellectual property of any Contributor under this Agreement,
+whether expressly, by implication, estoppel or otherwise. All rights in the
+Program not expressly granted under this Agreement are reserved.
+
+This Agreement is governed by the laws of the State of New York and the
+intellectual property laws of the United States of America. No party to this
+Agreement will bring a legal action under this Agreement more than one year
+after the cause of action arose. Each party waives its rights to a jury trial in
+any resulting litigation.
+
+

--- a/README.md
+++ b/README.md
@@ -15,43 +15,37 @@ repositories.
 Releases and Dependency Information
 ----------------------------------------
 
+This project follows the version scheme MAJOR.MINOR.PATCH where each component provides some relative indication of the size of the change, but does not follow semantic versioning. In general, all changes endeavor to be non-breaking (by moving to new names rather than by breaking existing names).
+
 [Change Log](CHANGES.md)
 
 [All Released Versions](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.clojure%22%20AND%20a%3A%22tools.namespace%22)
 
 ### Stable Release ###
 
-Latest stable release is [0.3.1](https://github.com/clojure/tools.namespace/tree/tools.namespace-0.3.1)
+Latest stable release is [1.0.0](https://github.com/clojure/tools.namespace/tree/tools.namespace-1.0.0)
 
 [Leiningen](http://leiningen.org/) stable dependency information:
 
-    [org.clojure/tools.namespace "0.3.1"]
+    [org.clojure/tools.namespace "1.0.0"]
 
 [Maven](http://maven.apache.org/) stable dependency information:
 
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>tools.namespace</artifactId>
-      <version>0.3.1</version>
+      <version>1.0.0</version>
     </dependency>
-
-### Development Release ###
-
-Latest development release is [0.3.1](https://github.com/clojure/tools.namespace/tree/tools.namespace-0.3.1)
-
-[Leiningen](http://leiningen.org/) latest dependency information:
-
-    [org.clojure/tools.namespace "0.3.1"]
 
 ### Development Snapshots ###
 
-Git master branch is at **0.3.2-SNAPSHOT**
+Git master branch is at **1.1.0-SNAPSHOT**
 
 [All Snapshot Versions](https://oss.sonatype.org/content/groups/public/org/clojure/tools.namespace/)
 
 Leiningen dependency information for development snapshots:
 
-    :dependencies [[org.clojure/tools.namespace "0.3.2-SNAPSHOT"]]
+    :dependencies [[org.clojure/tools.namespace "1.1.0-SNAPSHOT"]]
     :repositories [["sonatype-oss-public"
                     "https://oss.sonatype.org/content/groups/public/"]]
 

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ The "start" function should:
 The "stop" function should take the state returned by "start" as an
 argument and do the opposite:
 
-- Close or release stateful resourecs
+- Close or release stateful resources
 
 - Stop all background processes
 

--- a/README.md
+++ b/README.md
@@ -21,37 +21,37 @@ Releases and Dependency Information
 
 ### Stable Release ###
 
-Latest stable release is [0.3.0](https://github.com/clojure/tools.namespace/tree/tools.namespace-0.3.0)
+Latest stable release is [0.3.1](https://github.com/clojure/tools.namespace/tree/tools.namespace-0.3.1)
 
 [Leiningen](http://leiningen.org/) stable dependency information:
 
-    [org.clojure/tools.namespace "0.3.0"]
+    [org.clojure/tools.namespace "0.3.1"]
 
 [Maven](http://maven.apache.org/) stable dependency information:
 
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>tools.namespace</artifactId>
-      <version>0.3.0</version>
+      <version>0.3.1</version>
     </dependency>
 
 ### Development Release ###
 
-Latest development release is [0.3.0](https://github.com/clojure/tools.namespace/tree/tools.namespace-0.3.0)
+Latest development release is [0.3.1](https://github.com/clojure/tools.namespace/tree/tools.namespace-0.3.1)
 
 [Leiningen](http://leiningen.org/) latest dependency information:
 
-    [org.clojure/tools.namespace "0.3.0"]
+    [org.clojure/tools.namespace "0.3.1"]
 
 ### Development Snapshots ###
 
-Git master branch is at **0.3.1-SNAPSHOT**
+Git master branch is at **0.3.2-SNAPSHOT**
 
 [All Snapshot Versions](https://oss.sonatype.org/content/groups/public/org/clojure/tools.namespace/)
 
 Leiningen dependency information for development snapshots:
 
-    :dependencies [[org.clojure/tools.namespace "0.3.1-SNAPSHOT"]]
+    :dependencies [[org.clojure/tools.namespace "0.3.2-SNAPSHOT"]]
     :repositories [["sonatype-oss-public"
                     "https://oss.sonatype.org/content/groups/public/"]]
 

--- a/README.md
+++ b/README.md
@@ -37,21 +37,21 @@ Latest stable release is [0.2.11](https://github.com/clojure/tools.namespace/tre
 
 ### Development Release ###
 
-Latest development release is [0.3.0-alpha4](https://github.com/clojure/tools.namespace/tree/tools.namespace-0.3.0-alpha4)
+Latest development release is [0.3.0](https://github.com/clojure/tools.namespace/tree/tools.namespace-0.3.0)
 
 [Leiningen](http://leiningen.org/) latest dependency information:
 
-    [org.clojure/tools.namespace "0.3.0-alpha4"]
+    [org.clojure/tools.namespace "0.3.0"]
 
 ### Development Snapshots ###
 
-Git master branch is at **0.3.0-SNAPSHOT**
+Git master branch is at **0.3.1-SNAPSHOT**
 
 [All Snapshot Versions](https://oss.sonatype.org/content/groups/public/org/clojure/tools.namespace/)
 
 Leiningen dependency information for development snapshots:
 
-    :dependencies [[org.clojure/tools.namespace "0.3.0-SNAPSHOT"]]
+    :dependencies [[org.clojure/tools.namespace "0.3.1-SNAPSHOT"]]
     :repositories [["sonatype-oss-public"
                     "https://oss.sonatype.org/content/groups/public/"]]
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ evaluate any code.
 
 **clojure.tools.namespace.find:** Utilities to search for Clojure
 namespaces on the filesystem, in directories or JAR files. Combined
-with [java.classpath](https://clojure.github.com/java.classpath/), it
+with [java.classpath](https://clojure.github.io/java.classpath/), it
 can search for namespaces on the Java classpath. This namespace
 contains most of the functions in clojure.tools.namespace version
 0.1.x.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This project follows the version scheme MAJOR.MINOR.PATCH where each component p
 
 [Change Log](CHANGES.md)
 
-[All Released Versions](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.clojure%22%20AND%20a%3A%22tools.namespace%22)
+[All Released Versions](https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.clojure%22%20AND%20a%3A%22tools.namespace%22)
 
 ### Stable Release ###
 
@@ -30,11 +30,11 @@ Latest stable release is [1.1.0](https://github.com/clojure/tools.namespace/tree
 org.clojure/tools.namespace {:mvn/version "1.1.0"}
 ```
 
-[Leiningen](http://leiningen.org/) stable dependency information:
+[Leiningen](https://leiningen.org/) stable dependency information:
 
     [org.clojure/tools.namespace "1.1.0"]
 
-[Maven](http://maven.apache.org/) stable dependency information:
+[Maven](https://maven.apache.org/) stable dependency information:
 
     <dependency>
       <groupId>org.clojure</groupId>
@@ -54,14 +54,14 @@ Leiningen dependency information for development snapshots:
     :repositories [["sonatype-oss-public"
                     "https://oss.sonatype.org/content/groups/public/"]]
 
-See also [Maven Settings and Repositories](http://dev.clojure.org/display/doc/Maven+Settings+and+Repositories) on dev.clojure.org.
+See also [Maven Settings and Repositories](https://clojure.org/releases/downloads#_using_clojure_snapshot_releases) on dev.clojure.org.
 
 
 
 Overview
 ----------------------------------------
 
-[API Documentation](http://clojure.github.com/tools.namespace/)
+[API Documentation](https://clojure.github.io/tools.namespace/)
 
 tools.namespace consists of several parts:
 
@@ -74,7 +74,7 @@ evaluate any code.
 
 **clojure.tools.namespace.find:** Utilities to search for Clojure
 namespaces on the filesystem, in directories or JAR files. Combined
-with [java.classpath](http://clojure.github.com/java.classpath/), it
+with [java.classpath](https://clojure.github.com/java.classpath/), it
 can search for namespaces on the Java classpath. This namespace
 contains most of the functions in clojure.tools.namespace version
 0.1.x.
@@ -394,11 +394,11 @@ definitions, especially references to things you created in the REPL.
 dependency tracker, do not store it in a namespace which gets
 reloaded.
 
-[AOT-compiled]: http://clojure.org/compilation
+[AOT-compiled]: https://clojure.org/reference/compilation
 [Ring]: https://github.com/ring-clojure/ring
 [ns-tracker]: https://github.com/weavejester/ns-tracker
-[ns]: http://clojure.github.io/clojure/clojure.core-api.html#clojure.core/ns
-[require]: http://clojure.github.io/clojure/clojure.core-api.html#clojure.core/require
+[ns]: https://clojure.github.io/clojure/clojure.core-api.html#clojure.core/ns
+[require]: https://clojure.github.io/clojure/clojure.core-api.html#clojure.core/require
 
 
 ### Warnings for Helper Functions
@@ -563,16 +563,11 @@ Developer Information
 ----------------------------------------
 
 * [Change Log](CHANGES.md)
-
 * [GitHub project](https://github.com/clojure/tools.namespace)
-
-* [How to contribute](http://dev.clojure.org/display/community/Contributing)
-
-* [Bug Tracker](http://dev.clojure.org/jira/browse/TNS)
-
-* [Continuous Integration](http://build.clojure.org/job/tools.namespace/)
-
-* [Compatibility Test Matrix](http://build.clojure.org/job/tools.namespace-test-matrix/)
+* [How to contribute](https://clojure.org/community/contributing)
+* [Bug Tracker](https://clojure.atlassian.net/browse/TNS)
+* [Continuous Integration](https://build.clojure.org/job/tools.namespace/)
+* [Compatibility Test Matrix](https://build.clojure.org/job/tools.namespace-test-matrix/)
 
 
 
@@ -587,4 +582,4 @@ in any fashion, you are agreeing to be bound by the terms of this
 license. You must not remove this notice, or any other, from this
 software.
 
-[Eclipse Public License 1.0]: http://opensource.org/licenses/eclipse-1.0.php
+[Eclipse Public License 1.0]: https://opensource.org/licenses/eclipse-1.0.php

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ This project follows the version scheme MAJOR.MINOR.PATCH where each component p
 
 Latest stable release is [1.0.0](https://github.com/clojure/tools.namespace/tree/tools.namespace-1.0.0)
 
+[CLI/`deps.edn`](https://clojure.org/reference/deps_and_cli) dependency information:
+```clojure
+org.clojure/tools.namespace {:mvn/version "1.0.0"}
+```
+
 [Leiningen](http://leiningen.org/) stable dependency information:
 
     [org.clojure/tools.namespace "1.0.0"]

--- a/README.md
+++ b/README.md
@@ -23,28 +23,28 @@ This project follows the version scheme MAJOR.MINOR.PATCH where each component p
 
 ### Stable Release ###
 
-Latest stable release is [1.0.0](https://github.com/clojure/tools.namespace/tree/tools.namespace-1.0.0)
+Latest stable release is [1.1.0](https://github.com/clojure/tools.namespace/tree/tools.namespace-1.1.0)
 
 [CLI/`deps.edn`](https://clojure.org/reference/deps_and_cli) dependency information:
 ```clojure
-org.clojure/tools.namespace {:mvn/version "1.0.0"}
+org.clojure/tools.namespace {:mvn/version "1.1.0"}
 ```
 
 [Leiningen](http://leiningen.org/) stable dependency information:
 
-    [org.clojure/tools.namespace "1.0.0"]
+    [org.clojure/tools.namespace "1.1.0"]
 
 [Maven](http://maven.apache.org/) stable dependency information:
 
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>tools.namespace</artifactId>
-      <version>1.0.0</version>
+      <version>1.1.0</version>
     </dependency>
 
 ### Development Snapshots ###
 
-Git master branch is at **1.1.0-SNAPSHOT**
+Git master branch is at **1.2.0-SNAPSHOT**
 
 [All Snapshot Versions](https://oss.sonatype.org/content/groups/public/org/clojure/tools.namespace/)
 

--- a/README.md
+++ b/README.md
@@ -21,18 +21,18 @@ Releases and Dependency Information
 
 ### Stable Release ###
 
-Latest stable release is [0.2.11](https://github.com/clojure/tools.namespace/tree/tools.namespace-0.2.11)
+Latest stable release is [0.3.0](https://github.com/clojure/tools.namespace/tree/tools.namespace-0.3.0)
 
 [Leiningen](http://leiningen.org/) stable dependency information:
 
-    [org.clojure/tools.namespace "0.2.11"]
+    [org.clojure/tools.namespace "0.3.0"]
 
 [Maven](http://maven.apache.org/) stable dependency information:
 
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>tools.namespace</artifactId>
-      <version>0.2.11</version>
+      <version>0.3.0</version>
     </dependency>
 
 ### Development Release ###

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tools.namespace</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.1.0</version>
   <name>tools.namespace</name>
 
   <parent>
@@ -43,7 +43,7 @@
     <connection>scm:git:git@github.com:clojure/tools.namespace.git</connection>
     <developerConnection>scm:git:git@github.com:clojure/tools.namespace.git</developerConnection>
     <url>git@github.com:clojure/tools.namespace.git</url>
-    <tag>HEAD</tag>
+    <tag>tools.namespace-1.1.0</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tools.namespace</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0-SNAPSHOT</version>
   <name>tools.namespace</name>
 
   <parent>
@@ -43,7 +43,7 @@
     <connection>scm:git:git@github.com:clojure/tools.namespace.git</connection>
     <developerConnection>scm:git:git@github.com:clojure/tools.namespace.git</developerConnection>
     <url>git@github.com:clojure/tools.namespace.git</url>
-    <tag>tools.namespace-1.0.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tools.namespace</artifactId>
-  <version>0.3.1</version>
+  <version>0.3.2-SNAPSHOT</version>
   <name>tools.namespace</name>
 
   <parent>
@@ -43,7 +43,7 @@
     <connection>scm:git:git@github.com:clojure/tools.namespace.git</connection>
     <developerConnection>scm:git:git@github.com:clojure/tools.namespace.git</developerConnection>
     <url>git@github.com:clojure/tools.namespace.git</url>
-    <tag>tools.namespace-0.3.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tools.namespace</artifactId>
-  <version>0.3.0</version>
+  <version>0.3.1-SNAPSHOT</version>
   <name>tools.namespace</name>
 
   <parent>
@@ -43,7 +43,7 @@
     <connection>scm:git:git@github.com:clojure/tools.namespace.git</connection>
     <developerConnection>scm:git:git@github.com:clojure/tools.namespace.git</developerConnection>
     <url>git@github.com:clojure/tools.namespace.git</url>
-    <tag>tools.namespace-0.3.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tools.namespace</artifactId>
-  <version>0.3.0-SNAPSHOT</version>
+  <version>0.3.0</version>
   <name>tools.namespace</name>
 
   <parent>
@@ -43,7 +43,7 @@
     <connection>scm:git:git@github.com:clojure/tools.namespace.git</connection>
     <developerConnection>scm:git:git@github.com:clojure/tools.namespace.git</developerConnection>
     <url>git@github.com:clojure/tools.namespace.git</url>
-    <tag>HEAD</tag>
+    <tag>tools.namespace-0.3.0</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,14 +7,14 @@
   <parent>
     <groupId>org.clojure</groupId>
     <artifactId>pom.contrib</artifactId>
-    <version>0.2.2</version>
+    <version>1.0.0</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
-      <version>1.7.0</version>
+      <version>${clojure.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -31,6 +31,7 @@
 
   <properties>
     <clojure.warnOnReflection>true</clojure.warnOnReflection>
+    <clojure.version>1.7.0</clojure.version>
   </properties>
 
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tools.namespace</artifactId>
-  <version>0.3.1-SNAPSHOT</version>
+  <version>0.3.1</version>
   <name>tools.namespace</name>
 
   <parent>
@@ -43,7 +43,7 @@
     <connection>scm:git:git@github.com:clojure/tools.namespace.git</connection>
     <developerConnection>scm:git:git@github.com:clojure/tools.namespace.git</developerConnection>
     <url>git@github.com:clojure/tools.namespace.git</url>
-    <tag>HEAD</tag>
+    <tag>tools.namespace-0.3.1</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>tools.reader</artifactId>
-      <version>1.3.2</version>
+      <version>1.3.4</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tools.namespace</artifactId>
-  <version>0.3.2-SNAPSHOT</version>
+  <version>1.0.0</version>
   <name>tools.namespace</name>
 
   <parent>
@@ -43,7 +43,7 @@
     <connection>scm:git:git@github.com:clojure/tools.namespace.git</connection>
     <developerConnection>scm:git:git@github.com:clojure/tools.namespace.git</developerConnection>
     <url>git@github.com:clojure/tools.namespace.git</url>
-    <tag>HEAD</tag>
+    <tag>tools.namespace-1.0.0</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -20,12 +20,12 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>java.classpath</artifactId>
-      <version>0.2.3</version>
+      <version>0.3.0</version>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>tools.reader</artifactId>
-      <version>0.10.0</version>
+      <version>1.3.2</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tools.namespace</artifactId>
-  <version>1.1.0</version>
+  <version>1.2.0-SNAPSHOT</version>
   <name>tools.namespace</name>
 
   <parent>
@@ -43,7 +43,7 @@
     <connection>scm:git:git@github.com:clojure/tools.namespace.git</connection>
     <developerConnection>scm:git:git@github.com:clojure/tools.namespace.git</developerConnection>
     <url>git@github.com:clojure/tools.namespace.git</url>
-    <tag>tools.namespace-1.1.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.clojure</groupId>
     <artifactId>pom.contrib</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
   </parent>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>java.classpath</artifactId>
-      <version>0.3.0</version>
+      <version>1.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>


### PR DESCRIPTION
Partly as an experiment in seeing how the Fetch Upstream feature works, I created this PR to bring our fork up-to-date in preparation for `:as-alias`.